### PR TITLE
Loader API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,8 @@
 build/
 buildjunk/
 .vscode/
+.vs/
+*.xcworkspace/
 *.sln
 Makefile
-*.xcworkspace/
 .DS_Store

--- a/include/chrysalis/chrysalis.h
+++ b/include/chrysalis/chrysalis.h
@@ -6,7 +6,7 @@
  * @file
  * @brief Main header file
  * @author underdisk
- * @date May 2020 - May 2020
+ * @date May 2020 - June 2020
  * @copyright GNU Lesser General Public License v3.0
  */
 
@@ -29,47 +29,27 @@
 
 #pragma once
 
+#include <stdio.h>
+#include <string.h>
+
+#include "load.h"
 #include "gfx_api_info.h"
 #include "renderer.h"
 #include "util.h"
+#include "common.h"
+#include "whereami.c"
 
-#define __CHRYSALIS_VERSION_MAJOR__ 1
-#define __CHRYSALIS_VERSION_MINOR__ 0
+#define __CHRYSALIS_VERSION_MAJOR__ 0
+#define __CHRYSALIS_VERSION_MINOR__ 2
 #define __CHRYSALIS_VERSION_PATCH__ 0 // PATCH updates are not allowed to touch the API and therefore are not referenced in the headers
 
-/**
- * @brief Inits libchrysalis
- */
-void chs_init();
-
-/**
- * @brief Should be called at the end of the program / library use
- */
-void chs_quit();
-
-/**
- * @brief Major version of the loaded libchrysalis implementation
- * @returns Major version number of the loaded libchrysalis implementation
- */
-int chs_get_version_major();
-
-/**
- * @brief Minor version of the loaded libchrysalis implementation
- * @returns Minor version number of the loaded libchrysalis implementation
- */
-int chs_get_version_minor();
-
-/**
- * @brief Patch version of the loaded libchrysalis implementation
- * @returns Patch version number of the loaded libchrysalis implementation
- */
-int chs_get_version_patch();
-
-/**
- * @brief Information about the graphics api
- * @param[out] info CHS_Graphics_API_Info pointer to write to
- */
-void chs_get_graphics_api_info(CHS_Graphics_API_Info* info);
+// Function pointer list for loading
+void (*__chs_oninit_funcptr)();
+void (*__chs_onexit_funcptr)();
+int (*__chs_get_version_major_funcptr)();
+int (*__chs_get_version_minor_funcptr)();
+int (*__chs_get_version_patch_funcptr)();
+void (*__chs_get_graphics_api_info_funcptr)(CHS_Graphics_API_Info*);
 
 /**
  * @brief Checks if the libchrysalis headers and the loaded implementation do match
@@ -77,6 +57,111 @@ void chs_get_graphics_api_info(CHS_Graphics_API_Info* info);
  * @remark This function is implemented in the headers
  * @returns 1 if header and implementation versions do match, 0 if not
  */
+int chs_version_check();
+
+/**
+ * @brief Get the dynamic library extension per system
+ */
+
+const char* chs_private_get_dylib_file_ext()
+{
+	#ifdef __APPLE__
+		return ".dylib";
+	#elif defined(_WIN32) || defined(WIN32)
+		return ".dll";
+	#elif defined(unix) || defined(__unix__) || defined(__unix)
+		return ".so"
+	#endif
+}
+
+/**
+ * @brief Inits libchrysalis
+ */
+void chs_init(const char* implementation_str)
+{
+
+	//dirty way of doing things... didn't find a good alternative. thanks to @Lazy_Monique for the help
+	int path_len = wai_getExecutablePath(NULL, 0, NULL);
+	int dir_len;
+	char* path = (char*)malloc(path_len + 80);
+	wai_getExecutablePath(path, path_len, &dir_len);
+	path[path_len] = '\0'; //security
+
+	for (int i = path_len; i > 0; --i)
+	{
+		if (path[i] == '/')
+		{
+			path[i] = '\0';
+			break;
+		}
+	}
+
+	strcat(path, "/");
+	strcat(path, implementation_str);
+	strcat(path, chs_private_get_dylib_file_ext());
+
+	chs_private_load_library(path);
+
+	// CHRYSALIS.H
+	__chs_get_version_major_funcptr = chs_private_load_symbol("chs_get_version_major");
+	__chs_get_version_minor_funcptr = chs_private_load_symbol("chs_get_version_minor");
+	__chs_get_version_patch_funcptr = chs_private_load_symbol("chs_get_version_patch");
+	__chs_get_graphics_api_info_funcptr = chs_private_load_symbol("chs_get_graphics_api_info");
+
+	__chs_oninit_funcptr = chs_private_load_symbol("chs_oninit");
+	__chs_onexit_funcptr = chs_private_load_symbol("chs_onexit");
+
+	chs_private_load_window_funcptr();
+	chs_private_load_renderer_funcptr();
+
+	if (!chs_version_check())
+	{
+		chs_die("Implementation and header versions do not match");
+	}
+
+	(*__chs_oninit_funcptr)();
+
+	free(path);
+}
+
+
+/**
+ * @brief Should be called at the end of the program / library use
+ */
+void chs_quit()
+{
+	chs_private_close_library();
+	__chs_onexit_funcptr();
+}
+
+/**
+ * @brief Major version of the loaded libchrysalis implementation
+ * @returns Major version number of the loaded libchrysalis implementation
+ */
+int chs_get_version_major()
+{ return (*__chs_get_version_major_funcptr)(); }
+
+/**
+ * @brief Minor version of the loaded libchrysalis implementation
+ * @returns Minor version number of the loaded libchrysalis implementation
+ */
+int chs_get_version_minor()
+{ return (*__chs_get_version_minor_funcptr)(); }
+
+/**
+ * @brief Patch version of the loaded libchrysalis implementation
+ * @returns Patch version number of the loaded libchrysalis implementation
+ */
+int chs_get_version_patch()
+{ return (*__chs_get_version_patch_funcptr)(); }
+
+/**
+ * @brief Information about the graphics api
+ * @param[out] info CHS_Graphics_API_Info pointer to write to
+ */
+void chs_get_graphics_api_info(CHS_Graphics_API_Info* info)
+{ return (*__chs_get_graphics_api_info_funcptr)(info); }
+
 int chs_version_check()
 {
 	return (chs_get_version_major() == __CHRYSALIS_VERSION_MAJOR__) && (chs_get_version_minor() == __CHRYSALIS_VERSION_MINOR__);

--- a/include/chrysalis/chrysalis.h
+++ b/include/chrysalis/chrysalis.h
@@ -107,17 +107,17 @@ void chs_init(const char* implementation_str)
 
 	for (int i = path_len; i > 0; --i)
 	{
-		if (ret[i] == '/')
+		if (path[i] == '/')
 		{
-			ret[i] = '\0';
+			path[i] = '\0';
 			break;
 		}
 	}
 
-	strcat(ret, "/");
-	strcat(ret, chs_private_get_dylib_file_pre());
-	strcat(ret, implementation_str);
-	strcat(ret, chs_private_get_dylib_file_ext());
+	strcat(path, "/");
+	strcat(path, chs_private_get_dylib_file_pre());
+	strcat(path, implementation_str);
+	strcat(path, chs_private_get_dylib_file_ext());
 #endif
 
 	chs_private_load_library(path);

--- a/include/chrysalis/common.h
+++ b/include/chrysalis/common.h
@@ -1,0 +1,28 @@
+// libchrysalis is subject to the terms of the GNU Lesser General Public License v3.0
+// If a copy of the LGPLv3 was not distributed with this copy of the source code,
+// you can obtain one at https://www.gnu.org/licenses/lgpl-3.0.en.html
+
+/**
+ * @file
+ * @brief Default types
+ * @author underdisk
+ * @date June 2020 - June 2020
+ * @copyright GNU Lesser General Public License v3.0
+ */
+
+#pragma once
+
+#include <stdint.h>
+#include <stdbool.h>
+
+#ifndef bool
+	typedef _Bool bool; // _Bool is the C definition of the boolean type. let's use the bool keyword instead
+#endif
+typedef uint8_t u8;
+typedef int8_t i8;
+typedef uint16_t u16;
+typedef int16_t i16;
+typedef uint32_t u32;
+typedef int32_t i32;
+typedef uint64_t u64;
+typedef int64_t i64;

--- a/include/chrysalis/common.h
+++ b/include/chrysalis/common.h
@@ -15,9 +15,6 @@
 #include <stdint.h>
 #include <stdbool.h>
 
-#ifndef bool
-	typedef _Bool bool; // _Bool is the C definition of the boolean type. let's use the bool keyword instead
-#endif
 typedef uint8_t u8;
 typedef int8_t i8;
 typedef uint16_t u16;

--- a/include/chrysalis/load.h
+++ b/include/chrysalis/load.h
@@ -13,11 +13,13 @@
 #pragma once
 
 #if defined( __APPLE__) || defined(unix) || defined(__unix__) || defined(__unix) // macOS and other Unix(-like) including linux
-	
+
 	#include "load_unix.h"
 
 #elif defined(_WIN32) || defined(WIN32) // Microsoft Windows (32 and 64 bits)
-	// todo: Support Microsoft Windows
+
+	#include "load_win32.h"
+	
 #else
 	#error libchrysalis currently only supports macOS, GNU/Linux or Microsoft Windows
 #endif

--- a/include/chrysalis/load.h
+++ b/include/chrysalis/load.h
@@ -1,0 +1,23 @@
+// libchrysalis is subject to the terms of the GNU Lesser General Public License v3.0
+// If a copy of the LGPLv3 was not distributed with this copy of the source code,
+// you can obtain one at https://www.gnu.org/licenses/lgpl-3.0.en.html
+
+/**
+ * @file
+ * @brief Cross platform module loading header
+ * @author underdisk
+ * @date June 2020 - June 2020
+ * @copyright GNU Lesser General Public License v3.0
+ */
+
+#pragma once
+
+#if defined( __APPLE__) || defined(unix) || defined(__unix__) || defined(__unix) // macOS and other Unix(-like) including linux
+	
+	#include "load_unix.h"
+
+#elif defined(_WIN32) || defined(WIN32) // Microsoft Windows (32 and 64 bits)
+	// todo: Support Microsoft Windows
+#else
+	#error libchrysalis currently only supports macOS, GNU/Linux or Microsoft Windows
+#endif

--- a/include/chrysalis/load_unix.h
+++ b/include/chrysalis/load_unix.h
@@ -1,0 +1,50 @@
+// libchrysalis is subject to the terms of the GNU Lesser General Public License v3.0
+// If a copy of the LGPLv3 was not distributed with this copy of the source code,
+// you can obtain one at https://www.gnu.org/licenses/lgpl-3.0.en.html
+
+/**
+ * @file
+ * @brief Module loading header for Unix(-like) systems
+ * @author underdisk
+ * @date June 2020 - June 2020
+ * @copyright GNU Lesser General Public License v3.0
+ */
+
+#pragma once
+
+#include <dlfcn.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+typedef void* ____CHRYSALIS_IMP_HANDLE_T;
+
+____CHRYSALIS_IMP_HANDLE_T ____chrysalis_imp_handle__;
+
+void chs_private_load_library(const char* path)
+{
+	dlerror(); //clearing any error
+	____chrysalis_imp_handle__ = dlopen(path, RTLD_NOW);
+	if (____chrysalis_imp_handle__ == NULL)
+	{
+		fprintf(stderr, "Could not load libchrysalis implementation: %s\n", dlerror());
+        exit(-1);
+	}
+}
+
+void chs_private_close_library()
+{
+	dlclose(____chrysalis_imp_handle__);
+}
+
+void* chs_private_load_symbol(const char* symbol)
+{
+	dlerror(); //clearing any error
+	void* fun = dlsym(____chrysalis_imp_handle__, symbol);
+	if (fun == NULL)
+	{
+		fprintf(stderr, "Could not load libchrysalis symbol: %s\n", dlerror());
+        exit(-1);
+	}
+
+	return fun;
+}

--- a/include/chrysalis/load_win32.h
+++ b/include/chrysalis/load_win32.h
@@ -1,0 +1,67 @@
+// libchrysalis is subject to the terms of the GNU Lesser General Public License v3.0
+// If a copy of the LGPLv3 was not distributed with this copy of the source code,
+// you can obtain one at https://www.gnu.org/licenses/lgpl-3.0.en.html
+
+/**
+ * @file
+ * @brief Module loading header for windows systems
+ * @author underdisk
+ * @date June 2020 - June 2020
+ * @copyright GNU Lesser General Public License v3.0
+ */
+
+#pragma once
+
+#include <windows.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <strsafe.h>
+
+typedef HMODULE ____CHRYSALIS_IMP_HANDLE_T;
+
+____CHRYSALIS_IMP_HANDLE_T ____chrysalis_imp_handle__;
+
+void chs_private_print_win32_error(DWORD errorMessageID)
+{
+	LPSTR messageBuffer = NULL;
+	size_t size = FormatMessageA(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
+		NULL, errorMessageID, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), (LPSTR)&messageBuffer, 0, NULL);
+
+	MessageBoxA(
+		NULL,
+		messageBuffer,
+		NULL,
+		MB_OK | MB_ICONERROR
+	);
+
+	LocalFree(messageBuffer);
+}
+
+void chs_private_load_library(const char* path)
+{
+	____chrysalis_imp_handle__ = LoadLibraryExA(path, NULL, LOAD_LIBRARY_SEARCH_DEFAULT_DIRS);
+	if (____chrysalis_imp_handle__ == NULL)
+	{
+		DWORD error = GetLastError();
+		chs_private_print_win32_error(error);
+        exit(-1);
+	}
+}
+
+void chs_private_close_library()
+{
+	FreeLibrary(____chrysalis_imp_handle__);
+}
+
+void* chs_private_load_symbol(const char* symbol)
+{
+	void* fun = GetProcAddress(____chrysalis_imp_handle__, symbol);
+	if (fun == NULL)
+	{
+		DWORD error = GetLastError();
+		chs_private_print_win32_error(error);
+        exit(-1);
+	}
+
+	return fun;
+}

--- a/include/chrysalis/whereami.c
+++ b/include/chrysalis/whereami.c
@@ -1,0 +1,681 @@
+// (‑●‑●)> dual licensed under the WTFPL v2 and MIT licenses
+//   without any warranty.
+//   by Gregory Pakosz (@gpakosz)
+// https://github.com/gpakosz/whereami
+
+// in case you want to #include "whereami.c" in a larger compilation unit
+#if !defined(WHEREAMI_H)
+#include "whereami.h"
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#if !defined(WAI_MALLOC) || !defined(WAI_FREE) || !defined(WAI_REALLOC)
+#include <stdlib.h>
+#endif
+
+#if !defined(WAI_MALLOC)
+#define WAI_MALLOC(size) malloc(size)
+#endif
+
+#if !defined(WAI_FREE)
+#define WAI_FREE(p) free(p)
+#endif
+
+#if !defined(WAI_REALLOC)
+#define WAI_REALLOC(p, size) realloc(p, size)
+#endif
+
+#ifndef WAI_NOINLINE
+#if defined(_MSC_VER)
+#define WAI_NOINLINE __declspec(noinline)
+#elif defined(__GNUC__)
+#define WAI_NOINLINE __attribute__((noinline))
+#else
+#error unsupported compiler
+#endif
+#endif
+
+#if defined(_MSC_VER)
+#define WAI_RETURN_ADDRESS() _ReturnAddress()
+#elif defined(__GNUC__)
+#define WAI_RETURN_ADDRESS() __builtin_extract_return_addr(__builtin_return_address(0))
+#else
+#error unsupported compiler
+#endif
+
+#if defined(_WIN32)
+
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#if defined(_MSC_VER)
+#pragma warning(push, 3)
+#endif
+#include <windows.h>
+#include <intrin.h>
+#if defined(_MSC_VER)
+#pragma warning(pop)
+#endif
+
+static int WAI_PREFIX(getModulePath_)(HMODULE module, char* out, int capacity, int* dirname_length)
+{
+  wchar_t buffer1[MAX_PATH];
+  wchar_t buffer2[MAX_PATH];
+  wchar_t* path = NULL;
+  int length = -1;
+
+  for (;;)
+  {
+    DWORD size;
+    int length_, length__;
+
+    size = GetModuleFileNameW(module, buffer1, sizeof(buffer1) / sizeof(buffer1[0]));
+
+    if (size == 0)
+      break;
+    else if (size == (DWORD)(sizeof(buffer1) / sizeof(buffer1[0])))
+    {
+      DWORD size_ = size;
+      do
+      {
+        wchar_t* path_;
+
+        path_ = (wchar_t*)WAI_REALLOC(path, sizeof(wchar_t) * size_ * 2);
+        if (!path_)
+          break;
+        size_ *= 2;
+        path = path_;
+        size = GetModuleFileNameW(module, path, size_);
+      }
+      while (size == size_);
+
+      if (size == size_)
+        break;
+    }
+    else
+      path = buffer1;
+
+    if (!_wfullpath(buffer2, path, MAX_PATH))
+      break;
+    length_ = (int)wcslen(buffer2);
+    length__ = WideCharToMultiByte(CP_UTF8, 0, buffer2, length_ , out, capacity, NULL, NULL);
+
+    if (length__ == 0)
+      length__ = WideCharToMultiByte(CP_UTF8, 0, buffer2, length_, NULL, 0, NULL, NULL);
+    if (length__ == 0)
+      break;
+
+    if (length__ <= capacity && dirname_length)
+    {
+      int i;
+
+      for (i = length__ - 1; i >= 0; --i)
+      {
+        if (out[i] == '\\')
+        {
+          *dirname_length = i;
+          break;
+        }
+      }
+    }
+
+    length = length__;
+
+    break;
+  }
+
+  if (path != buffer1)
+    WAI_FREE(path);
+
+  return length;
+}
+
+WAI_NOINLINE WAI_FUNCSPEC
+int WAI_PREFIX(getExecutablePath)(char* out, int capacity, int* dirname_length)
+{
+  return WAI_PREFIX(getModulePath_)(NULL, out, capacity, dirname_length);
+}
+
+WAI_NOINLINE WAI_FUNCSPEC
+int WAI_PREFIX(getModulePath)(char* out, int capacity, int* dirname_length)
+{
+  HMODULE module;
+  int length = -1;
+
+#if defined(_MSC_VER)
+#pragma warning(push)
+#pragma warning(disable: 4054)
+#endif
+  if (GetModuleHandleEx(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT, (LPCTSTR)WAI_RETURN_ADDRESS(), &module))
+#if defined(_MSC_VER)
+#pragma warning(pop)
+#endif
+  {
+    length = WAI_PREFIX(getModulePath_)(module, out, capacity, dirname_length);
+  }
+
+  return length;
+}
+
+#elif defined(__linux__) || defined(__CYGWIN__) || defined(__sun) || defined(WAI_USE_PROC_SELF_EXE)
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#if defined(__linux__)
+#include <linux/limits.h>
+#else
+#include <limits.h>
+#endif
+#ifndef __STDC_FORMAT_MACROS
+#define __STDC_FORMAT_MACROS
+#endif
+#include <inttypes.h>
+
+#if !defined(WAI_PROC_SELF_EXE)
+#if defined(__sun)
+#define WAI_PROC_SELF_EXE "/proc/self/path/a.out"
+#else
+#define WAI_PROC_SELF_EXE "/proc/self/exe"
+#endif
+#endif
+
+WAI_FUNCSPEC
+int WAI_PREFIX(getExecutablePath)(char* out, int capacity, int* dirname_length)
+{
+  char buffer[PATH_MAX];
+  char* resolved = NULL;
+  int length = -1;
+
+  for (;;)
+  {
+    resolved = realpath(WAI_PROC_SELF_EXE, buffer);
+    if (!resolved)
+      break;
+
+    length = (int)strlen(resolved);
+    if (length <= capacity)
+    {
+      memcpy(out, resolved, length);
+
+      if (dirname_length)
+      {
+        int i;
+
+        for (i = length - 1; i >= 0; --i)
+        {
+          if (out[i] == '/')
+          {
+            *dirname_length = i;
+            break;
+          }
+        }
+      }
+    }
+
+    break;
+  }
+
+  return length;
+}
+
+#if !defined(WAI_PROC_SELF_MAPS_RETRY)
+#define WAI_PROC_SELF_MAPS_RETRY 5
+#endif
+
+#if !defined(WAI_PROC_SELF_MAPS)
+#if defined(__sun)
+#define WAI_PROC_SELF_MAPS "/proc/self/map"
+#else
+#define WAI_PROC_SELF_MAPS "/proc/self/maps"
+#endif
+#endif
+
+#if defined(__ANDROID__) || defined(ANDROID)
+#include <fcntl.h>
+#include <sys/mman.h>
+#include <unistd.h>
+#endif
+
+WAI_NOINLINE WAI_FUNCSPEC
+int WAI_PREFIX(getModulePath)(char* out, int capacity, int* dirname_length)
+{
+  int length = -1;
+  FILE* maps = NULL;
+
+  for (int r = 0; r < WAI_PROC_SELF_MAPS_RETRY; ++r)
+  {
+    maps = fopen(WAI_PROC_SELF_MAPS, "r");
+    if (!maps)
+      break;
+
+    for (;;)
+    {
+      char buffer[PATH_MAX < 1024 ? 1024 : PATH_MAX];
+      uint64_t low, high;
+      char perms[5];
+      uint64_t offset;
+      uint32_t major, minor;
+      char path[PATH_MAX];
+      uint32_t inode;
+
+      if (!fgets(buffer, sizeof(buffer), maps))
+        break;
+
+      if (sscanf(buffer, "%" PRIx64 "-%" PRIx64 " %s %" PRIx64 " %x:%x %u %s\n", &low, &high, perms, &offset, &major, &minor, &inode, path) == 8)
+      {
+        uint64_t addr = (uintptr_t)WAI_RETURN_ADDRESS();
+        if (low <= addr && addr <= high)
+        {
+          char* resolved;
+
+          resolved = realpath(path, buffer);
+          if (!resolved)
+            break;
+
+          length = (int)strlen(resolved);
+#if defined(__ANDROID__) || defined(ANDROID)
+          if (length > 4
+              &&buffer[length - 1] == 'k'
+              &&buffer[length - 2] == 'p'
+              &&buffer[length - 3] == 'a'
+              &&buffer[length - 4] == '.')
+          {
+            int fd = open(path, O_RDONLY);
+            char* begin;
+            char* p;
+
+            begin = (char*)mmap(0, offset + sizeof(p), PROT_READ, MAP_SHARED, fd, 0);
+            p = begin + offset;
+
+            while (p >= begin) // scan backwards
+            {
+              if (*((uint32_t*)p) == 0x04034b50UL) // local file header found
+              {
+                uint16_t length_ = *((uint16_t*)(p + 26));
+
+                if (length + 2 + length_ < (int)sizeof(buffer))
+                {
+                  memcpy(&buffer[length], "!/", 2);
+                  memcpy(&buffer[length + 2], p + 30, length_);
+                  length += 2 + length_;
+                }
+
+                break;
+              }
+
+              --p;
+            }
+
+            munmap(begin, offset);
+            close(fd);
+          }
+#endif
+          if (length <= capacity)
+          {
+            memcpy(out, resolved, length);
+
+            if (dirname_length)
+            {
+              int i;
+
+              for (i = length - 1; i >= 0; --i)
+              {
+                if (out[i] == '/')
+                {
+                  *dirname_length = i;
+                  break;
+                }
+              }
+            }
+          }
+
+          break;
+        }
+      }
+    }
+
+    fclose(maps);
+    maps = NULL;
+
+    if (length != -1)
+      break;
+  }
+
+  if (maps)
+    fclose(maps);
+
+  return length;
+}
+
+#elif defined(__APPLE__)
+
+#define _DARWIN_BETTER_REALPATH
+#include <mach-o/dyld.h>
+#include <limits.h>
+#include <stdlib.h>
+#include <string.h>
+#include <dlfcn.h>
+
+WAI_FUNCSPEC
+int WAI_PREFIX(getExecutablePath)(char* out, int capacity, int* dirname_length)
+{
+  char buffer1[PATH_MAX];
+  char buffer2[PATH_MAX];
+  char* path = buffer1;
+  char* resolved = NULL;
+  int length = -1;
+
+  for (;;)
+  {
+    uint32_t size = (uint32_t)sizeof(buffer1);
+    if (_NSGetExecutablePath(path, &size) == -1)
+    {
+      path = (char*)WAI_MALLOC(size);
+      if (!_NSGetExecutablePath(path, &size))
+        break;
+    }
+
+    resolved = realpath(path, buffer2);
+    if (!resolved)
+      break;
+
+    length = (int)strlen(resolved);
+    if (length <= capacity)
+    {
+      memcpy(out, resolved, length);
+
+      if (dirname_length)
+      {
+        int i;
+
+        for (i = length - 1; i >= 0; --i)
+        {
+          if (out[i] == '/')
+          {
+            *dirname_length = i;
+            break;
+          }
+        }
+      }
+    }
+
+    break;
+  }
+
+  if (path != buffer1)
+    WAI_FREE(path);
+
+  return length;
+}
+
+WAI_NOINLINE WAI_FUNCSPEC
+int WAI_PREFIX(getModulePath)(char* out, int capacity, int* dirname_length)
+{
+  char buffer[PATH_MAX];
+  char* resolved = NULL;
+  int length = -1;
+
+  for(;;)
+  {
+    Dl_info info;
+
+    if (dladdr(WAI_RETURN_ADDRESS(), &info))
+    {
+      resolved = realpath(info.dli_fname, buffer);
+      if (!resolved)
+        break;
+
+      length = (int)strlen(resolved);
+      if (length <= capacity)
+      {
+        memcpy(out, resolved, length);
+
+        if (dirname_length)
+        {
+          int i;
+
+          for (i = length - 1; i >= 0; --i)
+          {
+            if (out[i] == '/')
+            {
+              *dirname_length = i;
+              break;
+            }
+          }
+        }
+      }
+    }
+
+    break;
+  }
+
+  return length;
+}
+
+#elif defined(__QNXNTO__)
+
+#include <limits.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <dlfcn.h>
+
+#if !defined(WAI_PROC_SELF_EXE)
+#define WAI_PROC_SELF_EXE "/proc/self/exefile"
+#endif
+
+WAI_FUNCSPEC
+int WAI_PREFIX(getExecutablePath)(char* out, int capacity, int* dirname_length)
+{
+  char buffer1[PATH_MAX];
+  char buffer2[PATH_MAX];
+  char* resolved = NULL;
+  FILE* self_exe = NULL;
+  int length = -1;
+
+  for (;;)
+  {
+    self_exe = fopen(WAI_PROC_SELF_EXE, "r");
+    if (!self_exe)
+      break;
+
+    if (!fgets(buffer1, sizeof(buffer1), self_exe))
+      break;
+
+    resolved = realpath(buffer1, buffer2);
+    if (!resolved)
+      break;
+
+    length = (int)strlen(resolved);
+    if (length <= capacity)
+    {
+      memcpy(out, resolved, length);
+
+      if (dirname_length)
+      {
+        int i;
+
+        for (i = length - 1; i >= 0; --i)
+        {
+          if (out[i] == '/')
+          {
+            *dirname_length = i;
+            break;
+          }
+        }
+      }
+    }
+
+    break;
+  }
+
+  fclose(self_exe);
+
+  return length;
+}
+
+WAI_FUNCSPEC
+int WAI_PREFIX(getModulePath)(char* out, int capacity, int* dirname_length)
+{
+  char buffer[PATH_MAX];
+  char* resolved = NULL;
+  int length = -1;
+
+  for(;;)
+  {
+    Dl_info info;
+
+    if (dladdr(WAI_RETURN_ADDRESS(), &info))
+    {
+      resolved = realpath(info.dli_fname, buffer);
+      if (!resolved)
+        break;
+
+      length = (int)strlen(resolved);
+      if (length <= capacity)
+      {
+        memcpy(out, resolved, length);
+
+        if (dirname_length)
+        {
+          int i;
+
+          for (i = length - 1; i >= 0; --i)
+          {
+            if (out[i] == '/')
+            {
+              *dirname_length = i;
+              break;
+            }
+          }
+        }
+      }
+    }
+
+    break;
+  }
+
+  return length;
+}
+
+#elif defined(__DragonFly__) || defined(__FreeBSD__) || \
+      defined(__FreeBSD_kernel__) || defined(__NetBSD__)
+
+#include <limits.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/types.h>
+#include <sys/sysctl.h>
+#include <dlfcn.h>
+
+WAI_FUNCSPEC
+int WAI_PREFIX(getExecutablePath)(char* out, int capacity, int* dirname_length)
+{
+  char buffer1[PATH_MAX];
+  char buffer2[PATH_MAX];
+  char* path = buffer1;
+  char* resolved = NULL;
+  int length = -1;
+
+  for (;;)
+  {
+#if defined(__NetBSD__)
+    int mib[4] = { CTL_KERN, KERN_PROC_ARGS, -1, KERN_PROC_PATHNAME };
+#else
+    int mib[4] = { CTL_KERN, KERN_PROC, KERN_PROC_PATHNAME, -1 };
+#endif
+    size_t size = sizeof(buffer1);
+
+    if (sysctl(mib, (u_int)(sizeof(mib) / sizeof(mib[0])), path, &size, NULL, 0) != 0)
+        break;
+
+    resolved = realpath(path, buffer2);
+    if (!resolved)
+      break;
+
+    length = (int)strlen(resolved);
+    if (length <= capacity)
+    {
+      memcpy(out, resolved, length);
+
+      if (dirname_length)
+      {
+        int i;
+
+        for (i = length - 1; i >= 0; --i)
+        {
+          if (out[i] == '/')
+          {
+            *dirname_length = i;
+            break;
+          }
+        }
+      }
+    }
+
+    break;
+  }
+
+  if (path != buffer1)
+    WAI_FREE(path);
+
+  return length;
+}
+
+WAI_NOINLINE WAI_FUNCSPEC
+int WAI_PREFIX(getModulePath)(char* out, int capacity, int* dirname_length)
+{
+  char buffer[PATH_MAX];
+  char* resolved = NULL;
+  int length = -1;
+
+  for(;;)
+  {
+    Dl_info info;
+
+    if (dladdr(WAI_RETURN_ADDRESS(), &info))
+    {
+      resolved = realpath(info.dli_fname, buffer);
+      if (!resolved)
+        break;
+
+      length = (int)strlen(resolved);
+      if (length <= capacity)
+      {
+        memcpy(out, resolved, length);
+
+        if (dirname_length)
+        {
+          int i;
+
+          for (i = length - 1; i >= 0; --i)
+          {
+            if (out[i] == '/')
+            {
+              *dirname_length = i;
+              break;
+            }
+          }
+        }
+      }
+    }
+
+    break;
+  }
+
+  return length;
+}
+
+#else
+
+#error unsupported platform
+
+#endif
+
+#ifdef __cplusplus
+}
+#endif

--- a/include/chrysalis/whereami.h
+++ b/include/chrysalis/whereami.h
@@ -1,0 +1,67 @@
+// (‑●‑●)> dual licensed under the WTFPL v2 and MIT licenses
+//   without any warranty.
+//   by Gregory Pakosz (@gpakosz)
+// https://github.com/gpakosz/whereami
+
+#ifndef WHEREAMI_H
+#define WHEREAMI_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifndef WAI_FUNCSPEC
+  #define WAI_FUNCSPEC
+#endif
+#ifndef WAI_PREFIX
+#define WAI_PREFIX(function) wai_##function
+#endif
+
+/**
+ * Returns the path to the current executable.
+ *
+ * Usage:
+ *  - first call `int length = wai_getExecutablePath(NULL, 0, NULL);` to
+ *    retrieve the length of the path
+ *  - allocate the destination buffer with `path = (char*)malloc(length + 1);`
+ *  - call `wai_getExecutablePath(path, length, NULL)` again to retrieve the
+ *    path
+ *  - add a terminal NUL character with `path[length] = '\0';`
+ *
+ * @param out destination buffer, optional
+ * @param capacity destination buffer capacity
+ * @param dirname_length optional recipient for the length of the dirname part
+ *   of the path.
+ *
+ * @return the length of the executable path on success (without a terminal NUL
+ * character), otherwise `-1`
+ */
+WAI_FUNCSPEC
+int WAI_PREFIX(getExecutablePath)(char* out, int capacity, int* dirname_length);
+
+/**
+ * Returns the path to the current module
+ *
+ * Usage:
+ *  - first call `int length = wai_getModulePath(NULL, 0, NULL);` to retrieve
+ *    the length  of the path
+ *  - allocate the destination buffer with `path = (char*)malloc(length + 1);`
+ *  - call `wai_getModulePath(path, length, NULL)` again to retrieve the path
+ *  - add a terminal NUL character with `path[length] = '\0';`
+ *
+ * @param out destination buffer, optional
+ * @param capacity destination buffer capacity
+ * @param dirname_length optional recipient for the length of the dirname part
+ *   of the path.
+ *
+ * @return the length of the module path on success (without a terminal NUL
+ * character), otherwise `-1`
+ */
+WAI_FUNCSPEC
+int WAI_PREFIX(getModulePath)(char* out, int capacity, int* dirname_length);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // #ifndef WHEREAMI_H

--- a/include/chrysalis/window.h
+++ b/include/chrysalis/window.h
@@ -14,6 +14,7 @@
 
 #include <SDL2/SDL.h>
 #include <stdio.h>
+#include <stdlib.h>
 
 #include "load.h"
 

--- a/include/chrysalis_implementation/chrysalis.h
+++ b/include/chrysalis_implementation/chrysalis.h
@@ -1,0 +1,62 @@
+// libchrysalis is subject to the terms of the GNU Lesser General Public License v3.0
+// If a copy of the LGPLv3 was not distributed with this copy of the source code,
+// you can obtain one at https://www.gnu.org/licenses/lgpl-3.0.en.html
+
+/**
+ * @file
+ * @brief Main header file
+ * @author underdisk
+ * @date May 2020 - June 2020
+ * @copyright GNU Lesser General Public License v3.0
+ */
+
+/*! \mainpage libchrysalis
+ *
+ * \section intro_sec Introduction
+ *
+ * libchrysalis is a C library that acts as an abstraction layer for graphics API (OpenGL, Vulkan...)
+ * It consists of header files and different implementations for each graphics API
+ * 
+ * \section gettingstarted_sec Getting started
+ *
+ * The library is still in it's very-early stage. You can look at basic functions in the chrysalis.h header file
+ * 
+ * \section install_sec License
+ * 
+ * libchrysalis is subject to the terms of the GNU Lesser General Public License v3.0.
+ * you can obtain a copy of the license at https://www.gnu.org/licenses/lgpl-3.0.en.html
+ */
+
+#pragma once
+
+#include "gfx_api_info.h"
+#include "renderer.h"
+#include "util.h"
+
+#define __CHRYSALIS_VERSION_MAJOR__ 0
+#define __CHRYSALIS_VERSION_MINOR__ 2
+#define __CHRYSALIS_VERSION_PATCH__ 0 // PATCH updates are not allowed to touch the API and therefore are not referenced in the headers
+
+/**
+ * @brief Major version of the loaded libchrysalis implementation
+ * @returns Major version number of the loaded libchrysalis implementation
+ */
+int chs_get_version_major();
+
+/**
+ * @brief Minor version of the loaded libchrysalis implementation
+ * @returns Minor version number of the loaded libchrysalis implementation
+ */
+int chs_get_version_minor();
+
+/**
+ * @brief Patch version of the loaded libchrysalis implementation
+ * @returns Patch version number of the loaded libchrysalis implementation
+ */
+int chs_get_version_patch();
+
+/**
+ * @brief Information about the graphics api
+ * @param[out] info CHS_Graphics_API_Info pointer to write to
+ */
+void chs_get_graphics_api_info(CHS_Graphics_API_Info* info);

--- a/include/chrysalis_implementation/chrysalis.h
+++ b/include/chrysalis_implementation/chrysalis.h
@@ -32,6 +32,7 @@
 #include "gfx_api_info.h"
 #include "renderer.h"
 #include "util.h"
+#include "common.h"
 
 #define __CHRYSALIS_VERSION_MAJOR__ 0
 #define __CHRYSALIS_VERSION_MINOR__ 2
@@ -41,22 +42,26 @@
  * @brief Major version of the loaded libchrysalis implementation
  * @returns Major version number of the loaded libchrysalis implementation
  */
-int chs_get_version_major();
+CHRYSALIS_API_EXPORT int chs_get_version_major();
 
 /**
  * @brief Minor version of the loaded libchrysalis implementation
  * @returns Minor version number of the loaded libchrysalis implementation
  */
-int chs_get_version_minor();
+CHRYSALIS_API_EXPORT int chs_get_version_minor();
 
 /**
  * @brief Patch version of the loaded libchrysalis implementation
  * @returns Patch version number of the loaded libchrysalis implementation
  */
-int chs_get_version_patch();
+CHRYSALIS_API_EXPORT int chs_get_version_patch();
 
 /**
  * @brief Information about the graphics api
  * @param[out] info CHS_Graphics_API_Info pointer to write to
  */
-void chs_get_graphics_api_info(CHS_Graphics_API_Info* info);
+CHRYSALIS_API_EXPORT void chs_get_graphics_api_info(CHS_Graphics_API_Info* info);
+
+CHRYSALIS_API_EXPORT void chs_oninit();
+
+CHRYSALIS_API_EXPORT void chs_onexit();

--- a/include/chrysalis_implementation/color.h
+++ b/include/chrysalis_implementation/color.h
@@ -1,0 +1,39 @@
+// libchrysalis is subject to the terms of the GNU Lesser General Public License v3.0
+// If a copy of the LGPLv3 was not distributed with this copy of the source code,
+// you can obtain one at https://www.gnu.org/licenses/lgpl-3.0.en.html
+
+/**
+ * @file
+ * @brief Color header
+ * @author underdisk
+ * @date May 2020 - May 2020
+ * @copyright GNU Lesser General Public License v3.0
+ */
+
+#pragma once
+
+/**
+ * @brief Data type representing a color
+ */
+typedef struct
+CHS_Color {
+	/**
+	 * @brief Red
+	 */
+	float r;
+
+	/**
+	 * @brief Green
+	 */
+	float g;
+
+	/**
+	 * @brief Blue
+	 */
+	float b;
+
+	/**
+	 * @brief Alpha
+	 */
+	float a;
+}	CHS_Color;

--- a/include/chrysalis_implementation/common.h
+++ b/include/chrysalis_implementation/common.h
@@ -15,7 +15,15 @@
 #include <stdint.h>
 #include <stdbool.h>
 
-typedef bool _Bool; // _Bool is the C definition of the boolean type. let's use the bool keyword instead
+#if defined(_WIN32) || defined(WIN32)
+    #define CHRYSALIS_API_EXPORT __declspec( dllexport )
+#else
+    #define CHRYSALIS_API_EXPORT 
+#endif
+
+#ifndef bool
+    typedef _Bool bool; // _Bool is the C definition of the boolean type. let's use the bool keyword instead
+#endif
 typedef uint8_t u8;
 typedef int8_t i8;
 typedef uint16_t u16;

--- a/include/chrysalis_implementation/common.h
+++ b/include/chrysalis_implementation/common.h
@@ -1,0 +1,26 @@
+// libchrysalis is subject to the terms of the GNU Lesser General Public License v3.0
+// If a copy of the LGPLv3 was not distributed with this copy of the source code,
+// you can obtain one at https://www.gnu.org/licenses/lgpl-3.0.en.html
+
+/**
+ * @file
+ * @brief Default types
+ * @author underdisk
+ * @date June 2020 - June 2020
+ * @copyright GNU Lesser General Public License v3.0
+ */
+
+#pragma once
+
+#include <stdint.h>
+#include <stdbool.h>
+
+typedef bool _Bool; // _Bool is the C definition of the boolean type. let's use the bool keyword instead
+typedef uint8_t u8;
+typedef int8_t i8;
+typedef uint16_t u16;
+typedef int16_t i16;
+typedef uint32_t u32;
+typedef int32_t i32;
+typedef uint64_t u64;
+typedef int64_t i64;

--- a/include/chrysalis_implementation/gfx_api_info.h
+++ b/include/chrysalis_implementation/gfx_api_info.h
@@ -1,0 +1,34 @@
+// libchrysalis is subject to the terms of the GNU Lesser General Public License v3.0
+// If a copy of the LGPLv3 was not distributed with this copy of the source code,
+// you can obtain one at https://www.gnu.org/licenses/lgpl-3.0.en.html
+
+/**
+ * @file
+ * @brief Graphics API info type header
+ * @author underdisk
+ * @date May 2020 - May 2020
+ * @copyright GNU Lesser General Public License v3.0
+ */
+
+#pragma once
+
+/**
+ * @brief Contains information about a graphics API
+ */
+typedef struct
+CHS_Graphics_API_Info {
+	/**
+	 * @brief Null-terminated string representing the name of the graphics API.
+	 */
+	char* name;
+
+	/**
+	 * @brief Null-terminated string representing the oldest supported version of the graphics API
+	 */
+	char* oldest_version;
+
+	/**
+	 * @brief Null-terminated string representing the latest supported version of the graphics API
+	 */
+	char* latest_version;
+}	CHS_Graphics_API_Info;

--- a/include/chrysalis_implementation/renderer.h
+++ b/include/chrysalis_implementation/renderer.h
@@ -15,9 +15,6 @@
 #include "window.h"
 #include "color.h"
 
-#include "load.h"
-#include "common.h"
-
 /**
  * @brief Represents a renderer
  */
@@ -64,22 +61,6 @@ CHS_Renderer_Config {
 	int stencil_bits;
 }	CHS_Renderer_Config;
 
-CHS_Renderer* (*__chs_create_renderer_funcptr)(CHS_Renderer_Config*, CHS_Window*);
-void (*__chs_delete_renderer_funcptr)(CHS_Renderer*);
-void (*__chs_renderer_display_funcptr)(CHS_Renderer*);
-void (*__chs_renderer_set_clear_color_funcptr)(CHS_Renderer*, CHS_Color);
-void (*__chs_renderer_clear_funcptr)(CHS_Renderer*);
-
-void chs_private_load_renderer_funcptr()
-{
-	__chs_create_renderer_funcptr = chs_private_load_symbol("chs_create_renderer");
-	__chs_delete_renderer_funcptr = chs_private_load_symbol("chs_delete_renderer");
-	__chs_renderer_display_funcptr = chs_private_load_symbol("chs_renderer_display");
-	__chs_renderer_set_clear_color_funcptr = chs_private_load_symbol("chs_renderer_set_clear_color");
-	__chs_renderer_clear_funcptr = chs_private_load_symbol("chs_renderer_clear");
-}
-
-
 /**
  * @brief Creates a renderer
  * @param[in] config Configuration of the renderer
@@ -88,35 +69,30 @@ void chs_private_load_renderer_funcptr()
  * @details This field creates the renderer. It is also responsible of selecting/binding the
  * 			main framebuffer / backbuffer
  */
-CHS_Renderer* chs_create_renderer(CHS_Renderer_Config* config, CHS_Window* window)
-{ return (*__chs_create_renderer_funcptr)(config, window); }
+CHS_Renderer* chs_create_renderer(CHS_Renderer_Config* config, CHS_Window* window);
 
 /**
  * @brief Deletes a renderer
  * @param[in] renderer Pointer to the CHS_Renderer to destroy
  */
-void chs_delete_renderer(CHS_Renderer* renderer)
-{ return (*__chs_delete_renderer_funcptr)(renderer); }
+void chs_delete_renderer(CHS_Renderer* renderer);
 
 /**
  * @brief Display image (swap buffers)
  * @param[in] renderer Pointer to the CHS_Renderer to display
  */
-void chs_renderer_display(CHS_Renderer* renderer)
-{ return (*__chs_renderer_display_funcptr)(renderer); }
+void chs_renderer_display(CHS_Renderer* renderer);
 
 /**
  * @brief Changes the color that gets drawn when calling chs_renderer_clear()
  * @param[in] renderer Pointer to the CHS_Renderer to change the clear color of
  * @param[in] color Color to display when clearing
  */
-void chs_renderer_set_clear_color(CHS_Renderer* renderer, CHS_Color color)
-{ return (*__chs_renderer_set_clear_color_funcptr)(renderer, color); }
+void chs_renderer_set_clear_color(CHS_Renderer* renderer, CHS_Color color);
 
 /**
  * @brief Clears the screen with the color set using chs_renderer_set_clear_color()
  * @param[in] renderer Pointer to the CHS_Renderer to clear
  */
-void chs_renderer_clear(CHS_Renderer* renderer)
-{ return (*__chs_renderer_clear_funcptr)(renderer); }
+void chs_renderer_clear(CHS_Renderer* renderer);
 

--- a/include/chrysalis_implementation/renderer.h
+++ b/include/chrysalis_implementation/renderer.h
@@ -69,30 +69,30 @@ CHS_Renderer_Config {
  * @details This field creates the renderer. It is also responsible of selecting/binding the
  * 			main framebuffer / backbuffer
  */
-CHS_Renderer* chs_create_renderer(CHS_Renderer_Config* config, CHS_Window* window);
+CHRYSALIS_API_EXPORT CHS_Renderer* chs_create_renderer(CHS_Renderer_Config* config, CHS_Window* window);
 
 /**
  * @brief Deletes a renderer
  * @param[in] renderer Pointer to the CHS_Renderer to destroy
  */
-void chs_delete_renderer(CHS_Renderer* renderer);
+CHRYSALIS_API_EXPORT void chs_delete_renderer(CHS_Renderer* renderer);
 
 /**
  * @brief Display image (swap buffers)
  * @param[in] renderer Pointer to the CHS_Renderer to display
  */
-void chs_renderer_display(CHS_Renderer* renderer);
+CHRYSALIS_API_EXPORT void chs_renderer_display(CHS_Renderer* renderer);
 
 /**
  * @brief Changes the color that gets drawn when calling chs_renderer_clear()
  * @param[in] renderer Pointer to the CHS_Renderer to change the clear color of
  * @param[in] color Color to display when clearing
  */
-void chs_renderer_set_clear_color(CHS_Renderer* renderer, CHS_Color color);
+CHRYSALIS_API_EXPORT void chs_renderer_set_clear_color(CHS_Renderer* renderer, CHS_Color color);
 
 /**
  * @brief Clears the screen with the color set using chs_renderer_set_clear_color()
  * @param[in] renderer Pointer to the CHS_Renderer to clear
  */
-void chs_renderer_clear(CHS_Renderer* renderer);
+CHRYSALIS_API_EXPORT void chs_renderer_clear(CHS_Renderer* renderer);
 

--- a/include/chrysalis_implementation/util.h
+++ b/include/chrysalis_implementation/util.h
@@ -1,0 +1,25 @@
+// libchrysalis is subject to the terms of the GNU Lesser General Public License v3.0
+// If a copy of the LGPLv3 was not distributed with this copy of the source code,
+// you can obtain one at https://www.gnu.org/licenses/lgpl-3.0.en.html
+
+/**
+ * @file
+ * @brief Main header file
+ * @author underdisk
+ * @date May 2020 - May 2020
+ * @copyright GNU Lesser General Public License v3.0
+ */
+
+#pragma once
+
+#include <stdio.h>
+#include <stdlib.h>
+
+/**
+ * @brief Crashes the program with a message
+ */
+void chs_die(const char* reason)
+{
+	fprintf(stderr, "Error: %s", reason);
+	exit(-1);
+}

--- a/include/chrysalis_implementation/window.h
+++ b/include/chrysalis_implementation/window.h
@@ -13,9 +13,6 @@
 #pragma once
 
 #include <SDL2/SDL.h>
-#include <stdio.h>
-
-#include "load.h"
 
 /**
  * @brief Represents an OS window
@@ -64,26 +61,15 @@ CHS_Window_Config {
 	int high_dpi_support;
 }	CHS_Window_Config;
 
-Uint32 (*__chs_get_additional_sdl_window_flags_funcptr)();
-void (*__chs_before_window_creation_funcptr)(CHS_Window_Config*);
-
-void chs_private_load_window_funcptr()
-{
-	__chs_get_additional_sdl_window_flags_funcptr = chs_private_load_symbol("chs_get_additional_sdl_window_flags");
-	__chs_before_window_creation_funcptr = chs_private_load_symbol("chs_before_window_creation");
-}
-
 /**
  * @brief Returns additional SDL window flag used for context creation
  */
-Uint32 chs_get_additional_sdl_window_flags()
-{ return (*__chs_get_additional_sdl_window_flags_funcptr)(); }
+Uint32 chs_get_additional_sdl_window_flags();
 
 /**
  * @brief Called just before creating a SDL Window
  */
-void chs_before_window_creation(CHS_Window_Config* config)
-{ return (*__chs_before_window_creation_funcptr)(config); }
+void chs_before_window_creation(CHS_Window_Config* config);
 
 /**
  * @brief Creates and initializes a CHS_Window

--- a/include/chrysalis_implementation/window.h
+++ b/include/chrysalis_implementation/window.h
@@ -12,7 +12,10 @@
 
 #pragma once
 
+#include <stdio.h>
+#include <stdlib.h>
 #include <SDL2/SDL.h>
+#include "common.h"
 
 /**
  * @brief Represents an OS window
@@ -64,19 +67,19 @@ CHS_Window_Config {
 /**
  * @brief Returns additional SDL window flag used for context creation
  */
-Uint32 chs_get_additional_sdl_window_flags();
+CHRYSALIS_API_EXPORT Uint32 chs_get_additional_sdl_window_flags();
 
 /**
  * @brief Called just before creating a SDL Window
  */
-void chs_before_window_creation(CHS_Window_Config* config);
+CHRYSALIS_API_EXPORT void chs_before_window_creation(CHS_Window_Config* config);
 
 /**
  * @brief Creates and initializes a CHS_Window
  * @remark This function is implemented in the headers, but uses functions not implemented in the headers
  * @returns A valid CHS_Window pointer in case of success, NULL in case of failure
  */
-CHS_Window* chs_create_window(CHS_Window_Config* config)
+CHRYSALIS_API_EXPORT CHS_Window* chs_create_window(CHS_Window_Config* config)
 {
 	chs_before_window_creation(config);
 	CHS_Window* ret = (CHS_Window*)malloc(sizeof(CHS_Window));
@@ -101,7 +104,7 @@ CHS_Window* chs_create_window(CHS_Window_Config* config)
  * @brief Deletes a CHS_Window
  * @remark This function is implemented in the headers
  */
-void chs_delete_window(CHS_Window* window)
+CHRYSALIS_API_EXPORT void chs_delete_window(CHS_Window* window)
 {
 	free(window);
 }
@@ -110,7 +113,7 @@ void chs_delete_window(CHS_Window* window)
  * @brief Returns a unique number for each window
  * @remark This function is implemented in the headers
  */
-Uint32 chs_window_get_id(CHS_Window* window)
+CHRYSALIS_API_EXPORT Uint32 chs_window_get_id(CHS_Window* window)
 {
 	return SDL_GetWindowID(window->window);
 }

--- a/premake5.lua
+++ b/premake5.lua
@@ -49,6 +49,7 @@ project "chrysalis-gl"
 
 	libdirs {
 		("buildjunk/lib/" .. outputdir .. "/glew"),
+		_OPTIONS["SDL2_lib_path"]
 	}
 
 	filter "system:macosx"
@@ -64,14 +65,21 @@ project "chrysalis-gl"
 		"src/gl/**.c"
 	}
 
+	defines {
+		"GLEW_STATIC",
+		"GLEW_NO_GLU"
+	}
+
 	includedirs {
-		"include"
+		"include",
+		"deps/glew/include",
+		_OPTIONS["SDL2_include_path"]
 	}
 
 	postbuildcommands {
-		"{COPY} %{cfg.basedir}/include %{cfg.basedir}/build/include",
-		"cd %{cfg.basedir}/docs && doxygen",
-		"{MOVE} %{cfg.basedir}/docs/documentation %{cfg.basedir}/build/documentation"
+		--"{COPY} %{cfg.basedir}/include %{cfg.basedir}/build/include",
+		--"cd %{cfg.basedir}/docs && doxygen",
+		--"{MOVE} %{cfg.basedir}/docs/documentation %{cfg.basedir}/build/documentation/"
 	}
 
 	filter "configurations:debug"
@@ -95,10 +103,15 @@ project "sandbox"
 		--todo: Support linux
 	filter {}
 	files {
-		"src/sandbox.c"
+		"src/sandbox.c",
+		"include/chrysalis/**.h"
+	}
+	libdirs {
+		_OPTIONS["SDL2_lib_path"]
 	}
 	includedirs {
-		"build/include"
+		"include",
+		_OPTIONS["SDL2_include_path"]
 	}
 	filter "configurations:debug"
 		defines "CHRYSALIS_DEBUG"
@@ -106,6 +119,18 @@ project "sandbox"
 	filter "configurations:release"
 		defines "CHRYSALIS_RELEASE"
 		symbols "off"
+
+newoption {
+	trigger     = "SDL2_include_path",
+	value       = "path",
+	description = "include directory where the SDL2 headers can be found"
+}
+
+newoption {
+	trigger     = "SDL2_lib_path",
+	value       = "path",
+	description = "lib directory where the SDL2 library can be found"
+}
 
 newaction {
 	trigger     = "clean",

--- a/premake5.lua
+++ b/premake5.lua
@@ -83,17 +83,14 @@ project "chrysalis-gl"
 
 project "sandbox"
 	location "buildjunk/makefiles/sandbox"
-	kind "WindowedApp" 
+	kind "ConsoleApp" 
 	language "C"
 	targetdir ("build/bin/" .. outputdir .. "/%{prj.name}")
 	objdir ("buildjunk/obj/" .. outputdir .. "/%{prj.name}")
-	libdirs {
-		("build/lib/" .. outputdir .. "/chrysalis-gl"),
-	}
 	filter "system:macosx"
-		links { "OpenGL.framework", "SDL2", "chrysalis-gl" }
+		links { "OpenGL.framework", "SDL2" }
 	filter "system:windows" 
-		links { "opengl32", "SDL2", "chrysalis-gl" }
+		links { "opengl32", "SDL2" }
 	filter "system:linux"
 		--todo: Support linux
 	filter {}

--- a/src/gl/chrysalis-gl.c
+++ b/src/gl/chrysalis-gl.c
@@ -1,4 +1,4 @@
-#include <chrysalis/chrysalis.h>
+#include <chrysalis_implementation/chrysalis.h>
 
 #include "gl.h"
 
@@ -61,12 +61,12 @@ void chs_renderer_display(CHS_Renderer* renderer)
 
 int chs_get_version_major()
 {
-	return 1;
+	return 0;
 }
   
  int chs_get_version_minor()
  {
-	 return 0;
+	 return 2;
  }
   
  int chs_get_version_patch()
@@ -103,13 +103,13 @@ void chs_before_window_creation(CHS_Window_Config* config)
 	SDL_GL_SetAttribute( SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_CORE );
 }
 
-void chs_init()
+void chs_oninit()
 {
 	if (SDL_Init(SDL_INIT_VIDEO) < 0)
         chs_die("Unable to initialize SDL");
 }
 
-void chs_quit()
+void chs_onexit()
 {
 	SDL_Quit();
 }

--- a/src/sandbox.c
+++ b/src/sandbox.c
@@ -5,9 +5,9 @@
 int main()
 {
 	// Initialization, very important!
-	chs_init();
-	// Simple info display and checks
-	assert(chs_version_check() && "libchrysalis headers and implementation do not match");
+	// No need to provide a file extension. The file will be searched in the current
+	// executable directory
+	chs_init("libchrysalis-gl");
 
 	CHS_Graphics_API_Info gfx_api_info;
 	chs_get_graphics_api_info(&gfx_api_info);

--- a/src/sandbox.c
+++ b/src/sandbox.c
@@ -2,12 +2,17 @@
 #include <assert.h>
 #include <stdio.h>
 
+#ifdef _MSC_VER
+#    pragma comment(linker, "/subsystem:windows /ENTRY:mainCRTStartup")
+#endif
+
+#undef main
 int main()
 {
 	// Initialization, very important!
 	// No need to provide a file extension. The file will be searched in the current
 	// executable directory
-	chs_init("libchrysalis-gl");
+	chs_init("chrysalis-gl");
 
 	CHS_Graphics_API_Info gfx_api_info;
 	chs_get_graphics_api_info(&gfx_api_info);


### PR DESCRIPTION
Instead of loading the library directly, the headers now load the library at runtime. the implementation should be next to the executable (even on *nix systems)